### PR TITLE
Make add, addbike and delete commands inherit from ArgumentParser

### DIFF
--- a/src/main/java/loanbook/logic/parser/AddBikeCommandParser.java
+++ b/src/main/java/loanbook/logic/parser/AddBikeCommandParser.java
@@ -1,9 +1,8 @@
 package loanbook.logic.parser;
 
-import static loanbook.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static loanbook.logic.parser.CliSyntax.PREFIX_NAME;
 
-import java.util.stream.Stream;
+import java.util.List;
 
 import loanbook.logic.commands.AddBikeCommand;
 import loanbook.logic.parser.exceptions.ParseException;
@@ -11,37 +10,26 @@ import loanbook.model.bike.Bike;
 import loanbook.model.loan.Name;
 
 /**
- * Parses input arguments and creates a new AddBikeCommand object
+ * Parses input arguments and creates a new AddBikeCommand object.
  */
-public class AddBikeCommandParser implements Parser<AddBikeCommand> {
+public class AddBikeCommandParser extends ArgumentParser<AddBikeCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddBikeCommand
      * and returns an AddBikeCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseException if the user input does not conform the expected format.
      */
     public AddBikeCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-            ArgumentTokenizer.tokenize(args, PREFIX_NAME);
-
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
-            || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddBikeCommand.MESSAGE_USAGE));
-        }
+        ArgumentMultimap argMultimap = getArgumentMultimap(args,
+                List.of(PREFIX_NAME),
+                List.of(),
+                AddBikeCommand.MESSAGE_USAGE);
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
 
         Bike bike = new Bike(name);
 
         return new AddBikeCommand(bike);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/main/java/loanbook/logic/parser/AddCommandParser.java
+++ b/src/main/java/loanbook/logic/parser/AddCommandParser.java
@@ -1,6 +1,5 @@
 package loanbook.logic.parser;
 
-import static loanbook.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static loanbook.logic.parser.CliSyntax.PREFIX_BIKE;
 import static loanbook.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static loanbook.logic.parser.CliSyntax.PREFIX_LOANRATE;
@@ -9,8 +8,8 @@ import static loanbook.logic.parser.CliSyntax.PREFIX_NRIC;
 import static loanbook.logic.parser.CliSyntax.PREFIX_PHONE;
 import static loanbook.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import loanbook.logic.commands.AddCommand;
 import loanbook.logic.parser.exceptions.ParseException;
@@ -24,36 +23,20 @@ import loanbook.model.loan.Phone;
 import loanbook.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new AddCommand object
+ * Parses input arguments and creates a new AddCommand object.
  */
-public class AddCommandParser implements Parser<AddCommand> {
+public class AddCommandParser extends ArgumentParser<AddCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseException if the user input does not conform the expected format.
      */
     public AddCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args,
-                        PREFIX_NAME,
-                        PREFIX_NRIC,
-                        PREFIX_PHONE,
-                        PREFIX_EMAIL,
-                        PREFIX_BIKE,
-                        PREFIX_LOANRATE,
-                        PREFIX_TAG);
-
-        if (!arePrefixesPresent(argMultimap,
-                PREFIX_NAME,
-                PREFIX_NRIC,
-                PREFIX_PHONE,
-                PREFIX_EMAIL,
-                PREFIX_BIKE,
-                PREFIX_LOANRATE)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-        }
+        ArgumentMultimap argMultimap = getArgumentMultimap(args,
+                List.of(PREFIX_NAME, PREFIX_NRIC, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_BIKE, PREFIX_LOANRATE),
+                List.of(PREFIX_TAG),
+                AddCommand.MESSAGE_USAGE);
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
@@ -66,14 +49,6 @@ public class AddCommandParser implements Parser<AddCommand> {
         Loan loan = new Loan(name, nric, phone, email, bike, rate, tagList);
 
         return new AddCommand(loan);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/main/java/loanbook/logic/parser/ArgumentParser.java
+++ b/src/main/java/loanbook/logic/parser/ArgumentParser.java
@@ -1,0 +1,50 @@
+package loanbook.logic.parser;
+
+import static loanbook.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import loanbook.logic.commands.Command;
+import loanbook.logic.parser.exceptions.ParseException;
+
+/**
+ * Represents a Parser that parses a use input of only prefixed arguments for use by a {@code Command} of type {@code T}.
+ */
+public abstract class ArgumentParser<T extends Command> implements Parser<T> {
+
+    /**
+     * Generates an ArgumentMultimap from the given argument String and data specifications.
+     * @param argsString The String passed to the command, containing all the arguments.
+     * @param requiredArgs An array of Prefixes representing required data fields.
+     * @param optionalArgs An array of Prefixes representing optional data fields.
+     * @param msgUsage The message informing the user of the correct command usage.
+     * @return an ArgumentMultimap containing the data from {@code args}.
+     * @throws ParseException if the command does not have all required arguments, or has a pre-amble.
+     */
+    protected ArgumentMultimap getArgumentMultimap(
+            String argsString,
+            List<Prefix> requiredArgs,
+            List<Prefix> optionalArgs,
+            String msgUsage) throws ParseException {
+
+        List<Prefix> allArgs = new ArrayList();
+        allArgs.addAll(requiredArgs);
+        allArgs.addAll(optionalArgs);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, allArgs);
+
+        if (!arePrefixesPresent(argMultimap, requiredArgs) || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, msgUsage));
+        }
+
+        return argMultimap;
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, List<Prefix> prefixes) {
+        return prefixes.stream().allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/loanbook/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/loanbook/logic/parser/ArgumentTokenizer.java
@@ -24,6 +24,9 @@ public class ArgumentTokenizer {
      * @return           ArgumentMultimap object that maps prefixes to their arguments
      */
     public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) {
+        return tokenize(argsString, Arrays.asList(prefixes));
+    }
+    public static ArgumentMultimap tokenize(String argsString, List<Prefix> prefixes) {
         List<PrefixPosition> positions = findAllPrefixPositions(argsString, prefixes);
         return extractArguments(argsString, positions);
     }
@@ -35,8 +38,8 @@ public class ArgumentTokenizer {
      * @param prefixes   Prefixes to find in the arguments string
      * @return           List of zero-based prefix positions in the given arguments string
      */
-    private static List<PrefixPosition> findAllPrefixPositions(String argsString, Prefix... prefixes) {
-        return Arrays.stream(prefixes)
+    private static List<PrefixPosition> findAllPrefixPositions(String argsString, List<Prefix> prefixes) {
+        return prefixes.stream()
                 .flatMap(prefix -> findPrefixPositions(argsString, prefix).stream())
                 .collect(Collectors.toList());
     }

--- a/src/main/java/loanbook/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/loanbook/logic/parser/DeleteCommandParser.java
@@ -1,41 +1,35 @@
 package loanbook.logic.parser;
 
-import static loanbook.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static loanbook.logic.parser.CliSyntax.PREFIX_INDEX;
 import static loanbook.logic.parser.CliSyntax.PREFIX_PASSWORD;
 
-import java.util.stream.Stream;
+import java.util.List;
 
+import loanbook.commons.core.index.Index;
 import loanbook.logic.commands.DeleteCommand;
 import loanbook.logic.parser.exceptions.ParseException;
+import loanbook.model.Password;
 
 /**
- * Parses input arguments and creates a new DeleteCommand object
+ * Parses input arguments and creates a new DeleteCommand object.
  */
-public class DeleteCommandParser implements Parser<DeleteCommand> {
+public class DeleteCommandParser extends ArgumentParser<DeleteCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns an DeleteCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseException if the user input does not conform the expected format.
      */
     public DeleteCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_INDEX, PREFIX_PASSWORD);
-        if (!arePrefixesPresent(argMultimap, PREFIX_INDEX, PREFIX_PASSWORD)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-        }
-        return new DeleteCommand(ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get()),
-                ParserUtil.parsePass(argMultimap.getValue(PREFIX_PASSWORD).get()));
-    }
+        ArgumentMultimap argMultimap = getArgumentMultimap(args,
+                List.of(PREFIX_INDEX, PREFIX_PASSWORD),
+                List.of(),
+                DeleteCommand.MESSAGE_USAGE);
 
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
+        Password password = ParserUtil.parsePass(argMultimap.getValue(PREFIX_PASSWORD).get());
+
+        return new DeleteCommand(index, password);
     }
 
 }


### PR DESCRIPTION
The command parsers for`add`, `addbike` and `delete` exhibit similar behaviour. This PR extracts the common behaviour into a separate class.