### PR TITLE
Change return time display in LoanCard

### DIFF
--- a/src/main/java/loanbook/ui/LoanCard.java
+++ b/src/main/java/loanbook/ui/LoanCard.java
@@ -4,6 +4,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import loanbook.model.loan.Loan;
+import loanbook.model.loan.LoanTime;
 
 /**
  * An UI component that displays information of a {@code Loan}.
@@ -45,8 +46,10 @@ public class LoanCard extends ListCard<Loan> {
         bike.setText(loan.getBike().getName().value);
         rate.setText(loan.getLoanRate().toString());
         startTime.setText(loan.getLoanStartTime().toString());
-        // TODO Set the endtime to display correctly here
-        endTime.setText("PLACEHOLDER");
+
+        // Assign this variable so that we do not need to call the function twice.
+        LoanTime loanEndTime = loan.getLoanEndTime();
+        endTime.setText(loanEndTime == null ? "ONGOING" : loanEndTime.toString());
         initTags(loan);
     }
 


### PR DESCRIPTION
Currently the display says: `PLACEHOLDER`
I changed it to now display the actual value. It will display "ONGOING" if the endTime within the Loan object is null.

Fixes issue #171.