### PR TITLE
Update AddCommand example

### DIFF
--- a/src/main/java/loanbook/logic/commands/AddCommand.java
+++ b/src/main/java/loanbook/logic/commands/AddCommand.java
@@ -42,8 +42,8 @@ public class AddCommand extends Command {
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_BIKE + "Bike001 "
             + PREFIX_LOANRATE + "3.5 "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_TAG + "helmet "
+            + PREFIX_TAG + "discountedRate";
 
     public static final String MESSAGE_SUCCESS = "New loan added: %1$s";
     public static final String MESSAGE_LOANBOOK_FULL = "The loan book is full";


### PR DESCRIPTION
The old example for the `add` command adds tags that say "friends" and "owesMoney", which is inappropriate for a bicycle loan. This PR renames them to something more reasonable.